### PR TITLE
Support string tenant IDs in multi-tenant audit logging

### DIFF
--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -1202,8 +1202,10 @@ class ClickHouse extends SQL
                         $document[$columnName] = null;
                     } elseif (is_numeric($value)) {
                         $document[$columnName] = (int) $value;
-                    } else {
+                    } elseif (is_scalar($value)) {
                         $document[$columnName] = (string) $value;
+                    } else {
+                        $document[$columnName] = null;
                     }
                 } elseif ($columnName === 'time') {
                     // Convert ClickHouse timestamp format back to ISO 8601

--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -799,7 +799,7 @@ class ClickHouse extends SQL
             FORMAT JSON
         ";
 
-        $result = $this->query($sql, ['id' => $id]);
+        $result = $this->query($sql, array_merge(['id' => $id], $this->getTenantParams()));
         $logs = $this->parseJsonResults($result);
 
         return $logs[0] ?? null;
@@ -850,7 +850,7 @@ class ClickHouse extends SQL
             FORMAT JSON
         ";
 
-        $result = $this->query($sql, $parsed['params']);
+        $result = $this->query($sql, array_merge($parsed['params'], $this->getTenantParams()));
         return $this->parseJsonResults($result);
     }
 
@@ -890,7 +890,7 @@ class ClickHouse extends SQL
             FORMAT TabSeparated
         ";
 
-        $result = $this->query($sql, $params);
+        $result = $this->query($sql, array_merge($params, $this->getTenantParams()));
         $trimmed = trim($result);
 
         return $trimmed !== '' ? (int) $trimmed : 0;
@@ -1279,8 +1279,21 @@ class ClickHouse extends SQL
         }
 
         $escapedTenant = $this->escapeIdentifier('tenant');
-        $tenantValue = "'" . addslashes((string) $this->tenant) . "'";
-        return " AND {$escapedTenant} = {$tenantValue}";
+        return " AND {$escapedTenant} = {_tenant:String}";
+    }
+
+    /**
+     * Get query parameters for tenant filtering.
+     *
+     * @return array<string, mixed>
+     */
+    private function getTenantParams(): array
+    {
+        if (!$this->sharedTables || $this->tenant === null) {
+            return [];
+        }
+
+        return ['_tenant' => (string) $this->tenant];
     }
 
     /**
@@ -1571,7 +1584,7 @@ class ClickHouse extends SQL
             WHERE time < {datetime:String}{$tenantFilter}
         ";
 
-        $this->query($sql, ['datetime' => $datetimeString]);
+        $this->query($sql, array_merge(['datetime' => $datetimeString], $this->getTenantParams()));
 
         return true;
     }

--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -42,7 +42,7 @@ class ClickHouse extends SQL
 
     protected string $namespace = '';
 
-    protected ?int $tenant = null;
+    protected int|string|null $tenant = null;
 
     protected bool $sharedTables = false;
 
@@ -208,10 +208,10 @@ class ClickHouse extends SQL
      * Set the tenant ID for multi-tenant support.
      * Tenant is used to isolate audit logs by tenant.
      *
-     * @param int|null $tenant
+     * @param int|string|null $tenant
      * @return self
      */
-    public function setTenant(?int $tenant): self
+    public function setTenant(int|string|null $tenant): self
     {
         $this->tenant = $tenant;
         return $this;
@@ -220,9 +220,9 @@ class ClickHouse extends SQL
     /**
      * Get the tenant ID.
      *
-     * @return int|null
+     * @return int|string|null
      */
-    public function getTenant(): ?int
+    public function getTenant(): int|string|null
     {
         return $this->tenant;
     }
@@ -631,7 +631,7 @@ class ClickHouse extends SQL
 
         // Add tenant column only if tables are shared across tenants
         if ($this->sharedTables) {
-            $columns[] = 'tenant Nullable(UInt64)';  // Supports 11-digit MySQL auto-increment IDs
+            $columns[] = 'tenant Nullable(String)';
         }
 
         // Build indexes from base adapter schema
@@ -1197,13 +1197,13 @@ class ClickHouse extends SQL
                         $document[$columnName] = $value ?? [];
                     }
                 } elseif ($columnName === 'tenant') {
-                    // Parse tenant as integer or null
+                    // Parse tenant as int, string, or null
                     if ($value === null || $value === '') {
                         $document[$columnName] = null;
                     } elseif (is_numeric($value)) {
                         $document[$columnName] = (int) $value;
                     } else {
-                        $document[$columnName] = null;
+                        $document[$columnName] = (string) $value;
                     }
                 } elseif ($columnName === 'time') {
                     // Convert ClickHouse timestamp format back to ISO 8601
@@ -1279,7 +1279,8 @@ class ClickHouse extends SQL
         }
 
         $escapedTenant = $this->escapeIdentifier('tenant');
-        return " AND {$escapedTenant} = {$this->tenant}";
+        $tenantValue = "'" . addslashes((string) $this->tenant) . "'";
+        return " AND {$escapedTenant} = {$tenantValue}";
     }
 
     /**

--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -75,10 +75,16 @@ class ClickHouse extends SQL
      *
      * Determines the ClickHouse column type for the `tenant` column when
      * `setSharedTables(true)` is enabled:
-     * - `integer` → `Nullable(UInt64)`
-     * - anything else (default) → `Nullable(String)`
+     * - `integer` (default) → `Nullable(UInt64)`
+     * - anything else → `Nullable(String)`
+     *
+     * Defaults to `VAR_INTEGER` to preserve the previous schema on existing
+     * deployments: `reconcileTenantColumnType()` would otherwise trigger an
+     * irreversible `ALTER TABLE ... MODIFY COLUMN` from UInt64 to String on
+     * first `setup()` after upgrade. Callers using string IDs must opt in
+     * explicitly via {@see setIdAttributeType()}.
      */
-    protected string $idAttributeType = Database::VAR_UUID7;
+    protected string $idAttributeType = Database::VAR_INTEGER;
 
     /**
      * @param string $host ClickHouse host
@@ -1718,10 +1724,14 @@ class ClickHouse extends SQL
                         $document[$columnName] = $value ?? [];
                     }
                 } elseif ($columnName === 'tenant') {
-                    // Parse tenant as int, string, or null
+                    // Parse tenant according to the configured scheme:
+                    // - integer scheme → cast numeric values to int
+                    // - string scheme (uuid7 etc.) → keep verbatim so that
+                    //   numeric-looking IDs like "00123" or "42" round-trip
+                    //   without lossy coercion to int
                     if ($value === null || $value === '') {
                         $document[$columnName] = null;
-                    } elseif (is_numeric($value)) {
+                    } elseif ($this->idAttributeType === Database::VAR_INTEGER && is_numeric($value)) {
                         $document[$columnName] = (int) $value;
                     } elseif (is_scalar($value)) {
                         $document[$columnName] = (string) $value;

--- a/src/Audit/Log.php
+++ b/src/Audit/Log.php
@@ -126,9 +126,9 @@ class Log extends ArrayObject
     /**
      * Get the tenant ID (for multi-tenant setups).
      *
-     * @return int|null
+     * @return int|string|null
      */
-    public function getTenant(): ?int
+    public function getTenant(): int|string|null
     {
         $tenant = $this->getAttribute('tenant');
 
@@ -140,8 +140,8 @@ class Log extends ArrayObject
             return $tenant;
         }
 
-        if (is_numeric($tenant)) {
-            return (int) $tenant;
+        if (is_string($tenant)) {
+            return $tenant;
         }
 
         return null;

--- a/src/Audit/Log.php
+++ b/src/Audit/Log.php
@@ -140,10 +140,13 @@ class Log extends ArrayObject
             return $tenant;
         }
 
+        // Strings are returned as-is. The ClickHouse parser converts tenant
+        // values to int when the integer scheme is configured, so a string
+        // here means the host application is using a string-typed tenant
+        // (uuid7, slug, etc.) — coercing numeric-looking strings like
+        // "00123" would silently corrupt them.
         if (is_string($tenant)) {
-            // Numeric tenant IDs (e.g. legacy UInt64 rows stored as "123")
-            // round-trip back to int. Non-numeric strings stay as-is.
-            return is_numeric($tenant) ? (int) $tenant : $tenant;
+            return $tenant;
         }
 
         return null;

--- a/src/Audit/Log.php
+++ b/src/Audit/Log.php
@@ -140,6 +140,10 @@ class Log extends ArrayObject
             return $tenant;
         }
 
+        if (is_numeric($tenant)) {
+            return (int) $tenant;
+        }
+
         if (is_string($tenant)) {
             return $tenant;
         }

--- a/src/Audit/Log.php
+++ b/src/Audit/Log.php
@@ -140,10 +140,6 @@ class Log extends ArrayObject
             return $tenant;
         }
 
-        if (is_numeric($tenant)) {
-            return (int) $tenant;
-        }
-
         if (is_string($tenant)) {
             return $tenant;
         }

--- a/tests/Audit/Adapter/ClickHouseTest.php
+++ b/tests/Audit/Adapter/ClickHouseTest.php
@@ -778,15 +778,18 @@ class ClickHouseTest extends TestCase
         ]);
     }
 
-    public function testIdAttributeTypeDefaultsToString(): void
+    public function testIdAttributeTypeDefaultsToInteger(): void
     {
+        // Default is VAR_INTEGER to preserve the pre-existing schema on
+        // existing deployments — callers using string tenant IDs must opt
+        // in via setIdAttributeType().
         $adapter = new ClickHouse(
             host: 'clickhouse',
             username: 'default',
             password: 'clickhouse'
         );
 
-        $this->assertEquals(\Utopia\Database\Database::VAR_UUID7, $adapter->getIdAttributeType());
+        $this->assertEquals(\Utopia\Database\Database::VAR_INTEGER, $adapter->getIdAttributeType());
     }
 
     public function testIdAttributeTypeSetter(): void
@@ -808,7 +811,8 @@ class ClickHouseTest extends TestCase
         $chPort = (int) (getenv('CLICKHOUSE_PORT') ?: 8123);
         $required = $this->getRequiredAttributes();
 
-        // Default scheme (uuid7) → tenant column is Nullable(String)
+        // String scheme (uuid7) → tenant column is Nullable(String). Must
+        // opt in explicitly — default is VAR_INTEGER for BC.
         $stringAdapter = new ClickHouse(
             host: $chHost,
             username: 'default',
@@ -816,6 +820,7 @@ class ClickHouseTest extends TestCase
             port: $chPort
         );
         $stringAdapter->setNamespace('tenant_string_test');
+        $stringAdapter->setIdAttributeType(\Utopia\Database\Database::VAR_UUID7);
         $stringAdapter->setSharedTables(true);
         $stringAdapter->setTenant('uuid-tenant-1');
         $stringAdapter->setup();
@@ -824,9 +829,10 @@ class ClickHouseTest extends TestCase
         $stringAudit->log('u1', 'create', 'doc/1', 'agent', '127.0.0.1', 'US', $required);
         $logs = $stringAudit->find([Query::equal('userId', 'u1')]);
         $this->assertGreaterThanOrEqual(1, count($logs));
-        $this->assertEquals('uuid-tenant-1', $logs[0]->getTenant());
+        $this->assertSame('uuid-tenant-1', $logs[0]->getTenant());
 
-        // Integer scheme → tenant column is Nullable(UInt64), tenant is int
+        // Integer scheme (default) → tenant column is Nullable(UInt64),
+        // tenant is int.
         $intAdapter = new ClickHouse(
             host: $chHost,
             username: 'default',
@@ -834,7 +840,6 @@ class ClickHouseTest extends TestCase
             port: $chPort
         );
         $intAdapter->setNamespace('tenant_int_test');
-        $intAdapter->setIdAttributeType(\Utopia\Database\Database::VAR_INTEGER);
         $intAdapter->setSharedTables(true);
         $intAdapter->setTenant(42);
         $intAdapter->setup();
@@ -843,7 +848,38 @@ class ClickHouseTest extends TestCase
         $intAudit->log('u1', 'create', 'doc/1', 'agent', '127.0.0.1', 'US', $required);
         $intLogs = $intAudit->find([Query::equal('userId', 'u1')]);
         $this->assertGreaterThanOrEqual(1, count($intLogs));
-        // getTenant() returns int for numeric values regardless of column type
         $this->assertSame(42, $intLogs[0]->getTenant());
+    }
+
+    public function testNumericStringTenantPreservedInStringMode(): void
+    {
+        // Regression test: in uuid7 mode, a tenant ID that looks numeric
+        // (e.g. "42" or "00123") must round-trip back as a string, not
+        // silently cast to int by the parser or by Log::getTenant().
+        $chHost = getenv('CLICKHOUSE_HOST') ?: 'clickhouse';
+        $chPort = (int) (getenv('CLICKHOUSE_PORT') ?: 8123);
+
+        $adapter = new ClickHouse(
+            host: $chHost,
+            username: 'default',
+            password: 'clickhouse',
+            port: $chPort
+        );
+        $adapter->setNamespace('tenant_numstr_test');
+        $adapter->setIdAttributeType(\Utopia\Database\Database::VAR_UUID7);
+        $adapter->setSharedTables(true);
+        $adapter->setTenant('00123');
+        $adapter->setup();
+
+        $audit = new Audit($adapter);
+        $audit->log('u1', 'create', 'doc/1', 'agent', '127.0.0.1', 'US', $this->getRequiredAttributes());
+
+        $logs = $audit->find([Query::equal('userId', 'u1')]);
+        $this->assertGreaterThanOrEqual(1, count($logs));
+
+        // Strict equality — must stay a string, not int(123)
+        $tenant = $logs[0]->getTenant();
+        $this->assertIsString($tenant);
+        $this->assertSame('00123', $tenant);
     }
 }

--- a/tests/Audit/Adapter/ClickHouseTest.php
+++ b/tests/Audit/Adapter/ClickHouseTest.php
@@ -299,10 +299,14 @@ class ClickHouseTest extends TestCase
         $this->assertInstanceOf(ClickHouse::class, $result);
         $this->assertTrue($adapter->isSharedTables());
 
-        // Test setting tenant
+        // Test setting tenant to int
         $result2 = $adapter->setTenant(12345);
         $this->assertInstanceOf(ClickHouse::class, $result2);
         $this->assertEquals(12345, $adapter->getTenant());
+
+        // Test setting tenant to string
+        $adapter->setTenant('tenant_abc');
+        $this->assertSame('tenant_abc', $adapter->getTenant());
 
         // Test setting tenant to null
         $adapter->setTenant(null);


### PR DESCRIPTION
## Summary
Extended multi-tenant support in the ClickHouse audit adapter to accept string-based tenant identifiers in addition to integer IDs. This allows for more flexible tenant identification schemes (e.g., UUID, slug-based identifiers).

## Key Changes
- **Type signature updates**: Changed `tenant` property and related methods from `?int` to `int|string|null` across ClickHouse adapter and Log model
- **Database schema**: Updated ClickHouse tenant column from `Nullable(UInt64)` to `Nullable(String)` to support both numeric and string identifiers
- **Tenant parsing logic**: Modified JSON result parsing to preserve string tenant values instead of converting non-numeric values to null
- **Query filtering**: Updated tenant filter generation to properly escape string tenant values in SQL queries using `addslashes()`
- **Log model**: Simplified `getTenant()` method to return string values as-is instead of attempting numeric conversion
- **Test coverage**: Added test case validating string tenant ID assignment and retrieval

## Implementation Details
- The tenant column in ClickHouse now uses `String` type to accommodate both integer and string identifiers
- String tenant values are properly escaped when building SQL filter conditions
- Backward compatible: integer tenant IDs continue to work as before, being cast to integers during parsing
- The Log model's `getTenant()` method now returns string values directly without type coercion

https://claude.ai/code/session_01X8MFsu464fPHGaF7uPeWAZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant identifier handling expanded to accept numbers, strings, or null; tenant values are consistently treated as strings for storage and bound via parameters in queries and filters.

* **Tests**
  * Added coverage for numeric, string, and null tenant scenarios to validate multi-tenant behavior, parameterized filtering, and data operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->