### PR TITLE
Update fetch dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=8.4",
         "utopia-php/database": "5.*",
-        "utopia-php/fetch": "0.5.*",
+        "utopia-php/fetch": "^1.1",
         "utopia-php/query": "0.1.*",
         "utopia-php/validators": "0.2.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98622ab8912612e2e13a91c7786708f3",
+    "content-hash": "52e238097ee4b3c66f172cf8c9b3e86c",
     "packages": [
         {
             "name": "brick/math",
@@ -2182,16 +2182,16 @@
         },
         {
             "name": "utopia-php/fetch",
-            "version": "0.5.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/fetch.git",
-                "reference": "a96a010e1c273f3888765449687baf58cbc61fcd"
+                "reference": "64f2b3a789480f1deb102ce684dac4217d8e98d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/fetch/zipball/a96a010e1c273f3888765449687baf58cbc61fcd",
-                "reference": "a96a010e1c273f3888765449687baf58cbc61fcd",
+                "url": "https://api.github.com/repos/utopia-php/fetch/zipball/64f2b3a789480f1deb102ce684dac4217d8e98d5",
+                "reference": "64f2b3a789480f1deb102ce684dac4217d8e98d5",
                 "shasum": ""
             },
             "require": {
@@ -2200,7 +2200,8 @@
             "require-dev": {
                 "laravel/pint": "^1.5.0",
                 "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^9.5",
+                "swoole/ide-helper": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -2215,9 +2216,9 @@
             "description": "A simple library that provides an interface for making HTTP Requests.",
             "support": {
                 "issues": "https://github.com/utopia-php/fetch/issues",
-                "source": "https://github.com/utopia-php/fetch/tree/0.5.1"
+                "source": "https://github.com/utopia-php/fetch/tree/1.1.2"
             },
-            "time": "2025-12-18T16:25:10+00:00"
+            "time": "2026-04-29T11:19:19+00:00"
         },
         {
             "name": "utopia-php/framework",


### PR DESCRIPTION
## Summary

- Update `utopia-php/fetch` constraint from `0.5.*` to `^1.1`.
- Refresh `composer.lock` to install `utopia-php/fetch` `1.1.2`.

## Compatibility

`audit` uses `Utopia\Fetch\Client`, `Client::setTimeout()`, `Client::fetch()`, `Client::METHOD_POST`, `Response::getStatusCode()`, and `Response::getBody()` in `src/Audit/Adapter/ClickHouse.php`. These symbols are still available in `fetch` `1.1.2`.

## Test Plan

- `composer validate --strict`
- `composer run lint`
- `./vendor/bin/phpstan analyse --level max src tests --memory-limit=512M`

Notes:
- `composer audit` reports the existing `google/protobuf` advisory on the default dependency set; this PR only changes `utopia-php/fetch`.
- `vendor/bin/phpunit` requires local `clickhouse` and `mariadb` hostnames and fails in this environment because those services are not available.
