### PR TITLE
feat(clickhouse): Query::select + notStartsWith / notEndsWith / regex / orderRandom

### DIFF
--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -870,10 +870,16 @@ class ClickHouse extends SQL
         // Parse queries
         $parsed = $this->parseQueries($queries);
 
-        // Random ordering and cursor pagination are incompatible: cursor needs
-        // a stable order to anchor the next page on, rand() has none.
+        // Random ordering can't combine with anything that asks for a
+        // specific row order: cursor pagination needs a stable anchor, and
+        // mixing column-based ORDER BY with rand() would silently drop the
+        // column order. Reject loudly in both cases so the caller fixes the
+        // query rather than getting unexpected results.
         if (!empty($parsed['randomOrder']) && isset($parsed['cursor'])) {
             throw new Exception('Cursor pagination cannot be combined with orderRandom');
+        }
+        if (!empty($parsed['randomOrder']) && !empty($parsed['orderBy'])) {
+            throw new Exception('orderRandom cannot be combined with orderAsc/orderDesc');
         }
 
         // Build SELECT clause — respect Query::select if provided, otherwise
@@ -903,10 +909,11 @@ class ClickHouse extends SQL
             $whereClause = ' WHERE ' . implode(' AND ', $conditions);
         }
 
-        // Build ORDER BY clause. Random takes priority over column-based
-        // ordering, and otherwise: when cursor is in play, rebuild from
-        // orderAttributes (always non-empty after resolveCursorOrder, which
-        // appends an id tiebreaker), flipping directions for `cursorBefore`.
+        // Build ORDER BY clause. orderRandom is mutually exclusive with
+        // cursor and column ordering (rejected at the top of find()); when
+        // cursor is in play, rebuild from orderAttributes (always non-empty
+        // after resolveCursorOrder, which appends an id tiebreaker),
+        // flipping directions for `cursorBefore`.
         $orderClause = '';
         if (!empty($parsed['randomOrder'])) {
             $orderClause = ' ORDER BY rand()';
@@ -957,6 +964,10 @@ class ClickHouse extends SQL
             return $this->getSelectColumns();
         }
 
+        // Forced columns are injected here, so they're validated defensively.
+        // User-supplied columns in $select are already validated inside the
+        // TYPE_SELECT branch of parseQueries() — no need to walk
+        // getAttributes() a second time per column.
         $forced = ['id'];
         if ($this->sharedTables) {
             $forced[] = 'tenant';
@@ -964,11 +975,18 @@ class ClickHouse extends SQL
 
         $columns = [];
         $seen = [];
-        foreach (array_merge($forced, $select) as $column) {
+        foreach ($forced as $column) {
             if (isset($seen[$column])) {
                 continue;
             }
             $this->validateAttributeName($column);
+            $columns[] = $this->escapeIdentifier($column);
+            $seen[$column] = true;
+        }
+        foreach ($select as $column) {
+            if (isset($seen[$column])) {
+                continue;
+            }
             $columns[] = $this->escapeIdentifier($column);
             $seen[$column] = true;
         }

--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -943,8 +943,10 @@ class ClickHouse extends SQL
      * escapes each requested column.
      *
      * `id` is always projected so `parseJsonResults` can map it back to the
-     * `$id` field on the `Log` model. Callers requesting a slim projection
-     * don't have to remember to include it.
+     * `$id` field on the `Log` model. When `sharedTables` is enabled, the
+     * `tenant` column is also always projected — it's metadata callers expect
+     * on every row and the full-projection path already includes it. Callers
+     * requesting a slim projection don't have to remember either.
      *
      * @param  list<string>|null  $select
      * @throws Exception
@@ -955,9 +957,14 @@ class ClickHouse extends SQL
             return $this->getSelectColumns();
         }
 
+        $forced = ['id'];
+        if ($this->sharedTables) {
+            $forced[] = 'tenant';
+        }
+
         $columns = [];
         $seen = [];
-        foreach (array_merge(['id'], $select) as $column) {
+        foreach (array_merge($forced, $select) as $column) {
             if (isset($seen[$column])) {
                 continue;
             }

--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -42,7 +42,11 @@ class ClickHouse extends SQL
         Query::TYPE_CONTAINS,
         Query::TYPE_NOT_CONTAINS,
         Query::TYPE_STARTS_WITH,
+        Query::TYPE_NOT_STARTS_WITH,
         Query::TYPE_ENDS_WITH,
+        Query::TYPE_NOT_ENDS_WITH,
+        Query::TYPE_REGEX,
+        Query::TYPE_SELECT,
     ];
 
     private string $host;
@@ -866,8 +870,15 @@ class ClickHouse extends SQL
         // Parse queries
         $parsed = $this->parseQueries($queries);
 
-        // Build SELECT clause
-        $selectColumns = $this->getSelectColumns();
+        // Random ordering and cursor pagination are incompatible: cursor needs
+        // a stable order to anchor the next page on, rand() has none.
+        if (!empty($parsed['randomOrder']) && isset($parsed['cursor'])) {
+            throw new Exception('Cursor pagination cannot be combined with orderRandom');
+        }
+
+        // Build SELECT clause — respect Query::select if provided, otherwise
+        // fall back to the full column list.
+        $selectColumns = $this->buildProjection($parsed['select'] ?? null);
 
         $filters = $parsed['filters'];
         $params = $parsed['params'];
@@ -892,11 +903,14 @@ class ClickHouse extends SQL
             $whereClause = ' WHERE ' . implode(' AND ', $conditions);
         }
 
-        // Build ORDER BY clause — when cursor is in play, rebuild from
+        // Build ORDER BY clause. Random takes priority over column-based
+        // ordering, and otherwise: when cursor is in play, rebuild from
         // orderAttributes (always non-empty after resolveCursorOrder, which
         // appends an id tiebreaker), flipping directions for `cursorBefore`.
         $orderClause = '';
-        if (isset($parsed['cursor'])) {
+        if (!empty($parsed['randomOrder'])) {
+            $orderClause = ' ORDER BY rand()';
+        } elseif (isset($parsed['cursor'])) {
             $orderSql = $this->buildOrderBySql($orderAttributes, flip: $cursorDirection === 'before');
             $orderClause = ' ORDER BY ' . implode(', ', $orderSql);
         } elseif (!empty($parsed['orderBy'])) {
@@ -921,6 +935,38 @@ class ClickHouse extends SQL
         }
 
         return $rows;
+    }
+
+    /**
+     * Build the SELECT projection list. When `$select` is null, returns the
+     * full column list from `getSelectColumns()`; otherwise validates and
+     * escapes each requested column.
+     *
+     * `id` is always projected so `parseJsonResults` can map it back to the
+     * `$id` field on the `Log` model. Callers requesting a slim projection
+     * don't have to remember to include it.
+     *
+     * @param  list<string>|null  $select
+     * @throws Exception
+     */
+    private function buildProjection(?array $select): string
+    {
+        if ($select === null) {
+            return $this->getSelectColumns();
+        }
+
+        $columns = [];
+        $seen = [];
+        foreach (array_merge(['id'], $select) as $column) {
+            if (isset($seen[$column])) {
+                continue;
+            }
+            $this->validateAttributeName($column);
+            $columns[] = $this->escapeIdentifier($column);
+            $seen[$column] = true;
+        }
+
+        return implode(', ', $columns);
     }
 
     /**
@@ -985,7 +1031,7 @@ class ClickHouse extends SQL
      * Parse Query objects into SQL components.
      *
      * @param array<Query> $queries
-     * @return array{filters: array<string>, params: array<string, mixed>, orderBy?: array<string>, orderAttributes?: array<int, array{attribute: string, direction: string}>, limit?: int, offset?: int, cursor?: array<string, mixed>, cursorDirection?: string}
+     * @return array{filters: array<string>, params: array<string, mixed>, orderBy?: array<string>, orderAttributes?: array<int, array{attribute: string, direction: string}>, randomOrder?: bool, limit?: int, offset?: int, cursor?: array<string, mixed>, cursorDirection?: string, select?: list<string>}
      * @throws Exception
      */
     private function parseQueries(array $queries): array
@@ -998,6 +1044,8 @@ class ClickHouse extends SQL
         $offset = null;
         $cursor = null;
         $cursorDirection = null;
+        $select = null;
+        $randomOrder = false;
         $paramCounter = 0;
 
         foreach ($queries as $query) {
@@ -1163,6 +1211,18 @@ class ClickHouse extends SQL
                     $params[$paramName] = $needle;
                     break;
 
+                case Query::TYPE_NOT_STARTS_WITH:
+                    $this->validateAttributeName($attribute);
+                    $escapedAttr = $this->escapeIdentifier($attribute);
+                    $needle = $values[0] ?? null;
+                    if (!is_string($needle)) {
+                        throw new Exception("notStartsWith needle must be a string for attribute '{$attribute}'");
+                    }
+                    $paramName = 'param_' . $paramCounter++;
+                    $filters[] = "NOT startsWith({$escapedAttr}, {{$paramName}:String})";
+                    $params[$paramName] = $needle;
+                    break;
+
                 case Query::TYPE_ENDS_WITH:
                     $this->validateAttributeName($attribute);
                     $escapedAttr = $this->escapeIdentifier($attribute);
@@ -1173,6 +1233,55 @@ class ClickHouse extends SQL
                     $paramName = 'param_' . $paramCounter++;
                     $filters[] = "endsWith({$escapedAttr}, {{$paramName}:String})";
                     $params[$paramName] = $needle;
+                    break;
+
+                case Query::TYPE_NOT_ENDS_WITH:
+                    $this->validateAttributeName($attribute);
+                    $escapedAttr = $this->escapeIdentifier($attribute);
+                    $needle = $values[0] ?? null;
+                    if (!is_string($needle)) {
+                        throw new Exception("notEndsWith needle must be a string for attribute '{$attribute}'");
+                    }
+                    $paramName = 'param_' . $paramCounter++;
+                    $filters[] = "NOT endsWith({$escapedAttr}, {{$paramName}:String})";
+                    $params[$paramName] = $needle;
+                    break;
+
+                case Query::TYPE_REGEX:
+                    $this->validateAttributeName($attribute);
+                    $escapedAttr = $this->escapeIdentifier($attribute);
+                    $pattern = $values[0] ?? null;
+                    if (!is_string($pattern)) {
+                        throw new Exception("regex pattern must be a string for attribute '{$attribute}'");
+                    }
+                    $paramName = 'param_' . $paramCounter++;
+                    // ClickHouse's `match(haystack, pattern)` is the re2-style
+                    // regex predicate. Pattern is bound as a parameter, never
+                    // interpolated, so it can't escape into the SQL.
+                    $filters[] = "match({$escapedAttr}, {{$paramName}:String})";
+                    $params[$paramName] = $pattern;
+                    break;
+
+                case Query::TYPE_SELECT:
+                    if (empty($values)) {
+                        // VALUE_REQUIRED_METHODS already rejects empty values
+                        // earlier, but the explicit check keeps this branch safe
+                        // if the guard is ever bypassed.
+                        break;
+                    }
+                    // Multiple Query::select(...) calls combine into a single
+                    // projection. Duplicates are removed; column names are
+                    // validated and escaped at SQL build time in find().
+                    $select ??= [];
+                    foreach ($values as $column) {
+                        if (!is_string($column) || $column === '') {
+                            throw new Exception('select columns must be non-empty strings');
+                        }
+                        $this->validateAttributeName($column);
+                        if (!in_array($column, $select, true)) {
+                            $select[] = $column;
+                        }
+                    }
                     break;
 
                 case Query::TYPE_ORDER_DESC:
@@ -1187,6 +1296,13 @@ class ClickHouse extends SQL
                     $escapedAttr = $this->escapeIdentifier($attribute);
                     $orderBy[] = "{$escapedAttr} ASC";
                     $orderAttributes[] = ['attribute' => $attribute, 'direction' => 'ASC'];
+                    break;
+
+                case Query::TYPE_ORDER_RANDOM:
+                    // ClickHouse's rand() is the per-row PRNG used for random
+                    // sampling. Single emission across the result set — repeated
+                    // Query::orderRandom() calls collapse into one ORDER BY rand().
+                    $randomOrder = true;
                     break;
 
                 case Query::TYPE_LIMIT:
@@ -1231,6 +1347,10 @@ class ClickHouse extends SQL
             $result['orderAttributes'] = $orderAttributes;
         }
 
+        if ($randomOrder) {
+            $result['randomOrder'] = true;
+        }
+
         if ($limit !== null) {
             $result['limit'] = $limit;
         }
@@ -1242,6 +1362,10 @@ class ClickHouse extends SQL
         if ($cursor !== null && $cursorDirection !== null) {
             $result['cursor'] = $cursor;
             $result['cursorDirection'] = $cursorDirection;
+        }
+
+        if ($select !== null) {
+            $result['select'] = $select;
         }
 
         return $result;

--- a/tests/Audit/Adapter/ClickHouseTest.php
+++ b/tests/Audit/Adapter/ClickHouseTest.php
@@ -773,4 +773,98 @@ class ClickHouseTest extends TestCase
             new Query(Query::TYPE_EQUAL, 'event', []),
         ]);
     }
+
+    public function testSelectProjectsRequestedColumns(): void
+    {
+        $logs = $this->audit->find([
+            Query::select(['event', 'resource']),
+            Query::equal('userId', 'userId'),
+            Query::limit(1),
+        ]);
+
+        $this->assertGreaterThanOrEqual(1, count($logs));
+
+        $row = $logs[0]->getArrayCopy();
+        // `id` is always projected so the Log model still has its identifier
+        $this->assertArrayHasKey('$id', $row);
+        // Requested columns present
+        $this->assertArrayHasKey('event', $row);
+        $this->assertArrayHasKey('resource', $row);
+        // Unrequested columns are absent
+        $this->assertArrayNotHasKey('userAgent', $row);
+        $this->assertArrayNotHasKey('ip', $row);
+        $this->assertArrayNotHasKey('data', $row);
+    }
+
+    public function testSelectRejectsUnknownColumn(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid attribute name: bogus_column');
+
+        $this->audit->find([
+            Query::select(['bogus_column']),
+        ]);
+    }
+
+    public function testSelectRejectsEmptyValues(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Select queries require at least one value.');
+
+        $this->audit->find([
+            Query::select([]),
+        ]);
+    }
+
+    public function testNotStartsWithFilter(): void
+    {
+        $logs = $this->audit->find([
+            Query::notStartsWith('resource', 'database/'),
+        ]);
+        // From fixture: only 'user/null' doesn't start with 'database/'
+        $this->assertCount(1, $logs);
+        $this->assertEquals('user/null', $logs[0]->getResource());
+    }
+
+    public function testNotEndsWithFilter(): void
+    {
+        $logs = $this->audit->find([
+            Query::notEndsWith('resource', '/null'),
+        ]);
+        // From fixture: 3 logs are on database/document/{1,2,2}
+        $this->assertCount(3, $logs);
+        foreach ($logs as $log) {
+            $this->assertStringStartsNotWith('user/', $log->getResource());
+        }
+    }
+
+    public function testRegexFilter(): void
+    {
+        $logs = $this->audit->find([
+            Query::regex('resource', '^database/document/\\d+$'),
+        ]);
+        // From fixture: 3 database/document/{1,2,2} rows match
+        $this->assertCount(3, $logs);
+    }
+
+    public function testOrderRandomReturnsRows(): void
+    {
+        $logs = $this->audit->find([
+            Query::orderRandom(),
+            Query::limit(2),
+        ]);
+        // Hard to assert randomness; just confirm the query executes and limits.
+        $this->assertCount(2, $logs);
+    }
+
+    public function testOrderRandomRejectedWithCursor(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cursor pagination cannot be combined with orderRandom');
+
+        $this->audit->find([
+            Query::orderRandom(),
+            Query::cursorAfter(['id' => 'whatever']),
+        ]);
+    }
 }

--- a/tests/Audit/Adapter/ClickHouseTest.php
+++ b/tests/Audit/Adapter/ClickHouseTest.php
@@ -796,6 +796,39 @@ class ClickHouseTest extends TestCase
         $this->assertArrayNotHasKey('data', $row);
     }
 
+    public function testSelectAutoIncludesTenantWhenShared(): void
+    {
+        $host = getenv('CLICKHOUSE_HOST') ?: 'clickhouse';
+        $port = (int) (getenv('CLICKHOUSE_PORT') ?: 8123);
+
+        $adapter = new ClickHouse(
+            host: $host,
+            username: 'default',
+            password: 'clickhouse',
+            port: $port,
+        );
+        $adapter->setNamespace('select_tenant_test');
+        $adapter->setSharedTables(true);
+        $adapter->setTenant(7);
+        $adapter->setup();
+
+        $audit = new Audit($adapter);
+        $audit->log('u1', 'create', 'doc/1', 'agent', '127.0.0.1', 'US', $this->getRequiredAttributes());
+
+        $logs = $audit->find([
+            Query::select(['event']),
+            Query::limit(1),
+        ]);
+
+        $this->assertCount(1, $logs);
+        $row = $logs[0]->getArrayCopy();
+        $this->assertArrayHasKey('$id', $row);
+        $this->assertArrayHasKey('event', $row);
+        // tenant is always projected when sharedTables is on, even if the
+        // caller didn't list it
+        $this->assertArrayHasKey('tenant', $row);
+    }
+
     public function testSelectRejectsUnknownColumn(): void
     {
         $this->expectException(\Exception::class);

--- a/tests/Audit/Adapter/ClickHouseTest.php
+++ b/tests/Audit/Adapter/ClickHouseTest.php
@@ -900,4 +900,15 @@ class ClickHouseTest extends TestCase
             Query::cursorAfter(['id' => 'whatever']),
         ]);
     }
+
+    public function testOrderRandomRejectedWithColumnOrder(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('orderRandom cannot be combined with orderAsc/orderDesc');
+
+        $this->audit->find([
+            Query::orderRandom(),
+            Query::orderDesc('time'),
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary

Fills out the supported `Query` method set on the ClickHouse adapter so callers can opt into slim projections and the rest of the filter / order menu. Previously these methods were silently ignored when passed to `find()` (the projection always returned every column, etc.).

Added:

- **`Query::select(['col', ...])`** — column projection. Multiple `select()` calls combine; duplicates dropped; `id` is always projected so the `Log` model still has its identifier without callers having to remember. Each requested column is validated against the schema (`validateAttributeName`) and identifier-escaped at SQL build time. Without `select()`, the previous full-column behaviour is unchanged.
- **`Query::notStartsWith(...)` / `Query::notEndsWith(...)`** — symmetric with the existing `startsWith` / `endsWith`, compiled as `NOT startsWith(col, val)` / `NOT endsWith(col, val)`.
- **`Query::regex(col, pattern)`** — compiled to ClickHouse's `match(haystack, pattern)`. Pattern is parameter-bound, never inlined.
- **`Query::orderRandom()`** — `ORDER BY rand()`. Mutually exclusive with cursor pagination — combining the two throws because cursor needs a stable order to anchor the next page on.

`select`, `regex`, `notStartsWith`, `notEndsWith` were added to `VALUE_REQUIRED_METHODS` so they fail loudly with `Select queries require at least one value.` (etc.) on an empty values array, matching the existing contract.

## Why

Most directly, the cloud audit-events list endpoint is doing a `SELECT *` on rows with a sizeable `data` JSON payload — for UI listing pages that only need `id`, `time`, `event`, `userId`, `resource`, projecting just those columns avoids the dominant I/O cost. `Query::select` was the missing piece. Adding the rest while we're in here so the supported set matches `utopia-php/query`'s contract.

## Not in this PR

- `search` / `notSearch` — no fulltext index on the audit table
- `exists` / `notExists` — doc-store concept, doesn't map cleanly
- `containsAny` / `containsAll` / `elemMatch` — array-column methods, audit columns are scalar
- vector / spatial types — not applicable
- `and` / `or` logical combinations — would need a recursive filter compiler that doesn't exist today; filed as a follow-up

## API

```php
use Utopia\Audit\Query;

// Slim projection — read only the columns the UI needs
$logs = $audit->find([
    Query::select(['event', 'resource', 'userId', 'time']),
    Query::greaterThanEqual('time', '2026-05-07T00:00:00Z'),
    Query::orderDesc('time'),
    Query::limit(150),
]);

// notStartsWith / notEndsWith
$audit->find([Query::notStartsWith('resource', 'temp/')]);
$audit->find([Query::notEndsWith('resource', '.bak')]);

// Regex via ClickHouse match()
$audit->find([Query::regex('resource', '^database/document/\\d+$')]);

// Random ordering
$audit->find([Query::orderRandom(), Query::limit(10)]);
```

## Test plan

- [x] `composer lint` passes
- [x] `composer check` (PHPStan max) passes
- [x] 8 new tests cover the happy paths plus unknown-column rejection, empty-values rejection, and the cursor + random incompatibility
- [x] Full audit ClickHouse test suite: 61/61 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)