### PR TITLE
feat(clickhouse): add opt-in async cleanup via setAsyncCleanup()

### DIFF
--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -68,6 +68,8 @@ class ClickHouse extends SQL
 
     protected bool $sharedTables = false;
 
+    protected bool $asyncCleanup = false;
+
     /**
      * @param string $host ClickHouse host
      * @param string $username ClickHouse username (default: 'default')
@@ -294,6 +296,31 @@ class ClickHouse extends SQL
     public function isSharedTables(): bool
     {
         return $this->sharedTables;
+    }
+
+    /**
+     * Set whether cleanup() should return after scheduling the DELETE mutation
+     * rather than waiting for it to complete. When enabled, the DELETE is sent
+     * with `SETTINGS lightweight_deletes_sync = 0` and the HTTP call returns
+     * as soon as the mutation is queued.
+     *
+     * @param bool $asyncCleanup
+     * @return self
+     */
+    public function setAsyncCleanup(bool $asyncCleanup): self
+    {
+        $this->asyncCleanup = $asyncCleanup;
+        return $this;
+    }
+
+    /**
+     * Get whether cleanup() runs asynchronously.
+     *
+     * @return bool
+     */
+    public function isAsyncCleanup(): bool
+    {
+        return $this->asyncCleanup;
     }
 
     /**
@@ -1957,8 +1984,6 @@ class ClickHouse extends SQL
     /**
      * Delete logs older than the specified datetime.
      *
-     * ClickHouse uses ALTER TABLE DELETE with synchronous mutations.
-     *
      * @throws Exception
      */
     public function cleanup(\DateTime $datetime): bool
@@ -1967,14 +1992,13 @@ class ClickHouse extends SQL
         $tenantFilter = $this->getTenantFilter();
         $escapedTable = $this->escapeIdentifier($this->database) . '.' . $this->escapeIdentifier($tableName);
 
-        // Convert DateTime to string format expected by ClickHouse
         $datetimeString = $datetime->format('Y-m-d H:i:s.v');
 
-        // Use DELETE statement for synchronous deletion (ClickHouse 23.3+)
-        // Falls back to ALTER TABLE DELETE with mutations_sync for older versions
+        $settings = $this->asyncCleanup ? ' SETTINGS lightweight_deletes_sync = 0' : '';
+
         $sql = "
             DELETE FROM {$escapedTable}
-            WHERE time < {datetime:String}{$tenantFilter}
+            WHERE time < {datetime:String}{$tenantFilter}{$settings}
         ";
 
         $this->query($sql, ['datetime' => $datetimeString]);


### PR DESCRIPTION
## Summary

Add `setAsyncCleanup(bool)` to the ClickHouse adapter. When enabled, `cleanup()` appends `SETTINGS lightweight_deletes_sync = 0` so the HTTP call returns once the mutation is queued, instead of blocking until ClickHouse finishes the DELETE. Default behavior is unchanged.

## Why

In production, the maintenance worker invokes `cleanup()` per project against a shared multi-tenant audit table. The synchronous DELETE routinely exceeded the 30s client timeout:

```
Failed to cleanup ClickHouse audit logs for project <id>:
ClickHouse query execution failed: Operation timed out after 30026 milliseconds with 0 bytes received
```

Two factors compound:
1. `tenant` is not in the table's sort key or skip-index set, so the per-tenant predicate forces a row-level scan inside surviving parts.
2. `SharedMergeTree` serializes mutations per table through Keeper, so N per-project mutations queue up and the HTTP client times out long before they drain.

The maintenance worker only needs to schedule cleanup, not wait for it.

## Why opt-in (not default)

The first iteration of this PR made async unconditional and broke `testCleanup`, `testFind`, `testCount` — they assert on row counts immediately after `cleanup()`. Making it opt-in via a setter:
- preserves the existing contract for every other consumer (and for the test suite),
- matches the existing `setSharedTables` / `setTenant` configuration style on this adapter,
- lets cloud's deletes worker opt in with a single line: `$auditAdapter->setAsyncCleanup(true)`.

## Test plan

- [x] `composer lint` (Pint)
- [x] `composer check` (PHPStan level max, no errors)
- [ ] CI: existing test suite passes (default-sync behavior is untouched)
- [ ] Cloud follow-up: deletes worker calls `setAsyncCleanup(true)` and verifies the 30s timeout is gone in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
