### PR TITLE
chore: bump test image to PHP 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY composer.json /src/
 RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist
 
-FROM php:8.3.3-cli-alpine3.19 AS final
+FROM php:8.4-cli-alpine AS final
 
 LABEL maintainer="team@appwrite.io"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY composer.json /src/
 RUN composer install --ignore-platform-reqs --optimize-autoloader \
     --no-plugins --no-scripts --prefer-dist
 
-FROM php:8.4-cli-alpine AS final
+FROM php:8.4.18-cli-alpine3.22 AS final
 
 LABEL maintainer="team@appwrite.io"
 


### PR DESCRIPTION
## Summary

`composer.json` requires `php: >=8.4` (since the migration to `utopia-php/query` 0.1.x), but the test `Dockerfile` is still pinned at `php:8.3.3-cli-alpine3.19`. Any PHP 8.4-only syntax in a dependency — e.g. asymmetric visibility (`public protected(set)`) introduced on the in-flight `utopia-php/query` 0.3.x branch — fails to parse before tests even start.

Bumps the image to `php:8.4-cli-alpine`. No other changes.

## Test plan

- [x] Composer + PHPStan + Pint all already require 8.4 — no source changes needed.
- [ ] CI green on this PR (smoke test for the existing suite under 8.4).
- [ ] Unblocks PR #120 (utopia-php/query 0.3.x migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)