### PR TITLE
fix(clickhouse): use isset() instead of array_key_exists() for Log object in createBatch

### DIFF
--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -1685,7 +1685,7 @@ class ClickHouse extends SQL
 
         foreach ($logs as $log) {
             foreach (['userId' => 'actorId', 'userType' => 'actorType', 'userInternalId' => 'actorInternalId'] as $legacy => $current) {
-                if (\array_key_exists($legacy, $log) && !\array_key_exists($current, $log)) {
+                if (isset($log[$legacy]) && !isset($log[$current])) {
                     $log[$current] = $log[$legacy];
                 }
                 unset($log[$legacy]);


### PR DESCRIPTION
## Summary

The legacy-translation block added in #122 (2.4.0) calls `\array_key_exists($legacy, $log)` on each `$log` in the batch. When callers pass `Utopia\Audit\Log` (an ArrayAccess subclass of `Document`) — as Appwrite Cloud's Activity worker does via `getClickHouseAdapter()->createBatch([new Log(...), ...])` — PHP 8 throws:

```
TypeError: array_key_exists(): Argument #2 ($array) must be of type array, Utopia\Audit\Log given
```

The whole batch insert then fails (caught silently downstream), so no rows land in ClickHouse.

`isset($log[$key])` does the same intent here (only false for absent or null values, and null userId/userType/userInternalId is never meaningful in this code path) and works for both plain arrays and ArrayAccess objects.

## Test plan

- [ ] Existing unit tests pass
- [ ] Verified locally that `createBatch([new Log(['actorId' => '...', 'actorType' => '...', ...])])` no longer throws TypeError
- [ ] Appwrite Cloud Activities E2E (downstream consumer) now writes rows successfully
