### PR TITLE
Backport tenant-leading ClickHouse sort key + LowCardinality (2.4.x → 2.4.3)

### DIFF
--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -24,6 +24,16 @@ class ClickHouse extends SQL
     private const DEFAULT_DATABASE = 'default';
 
     /**
+     * @var list<string>
+     */
+    private const LOW_CARDINALITY_COLUMNS = [
+        'event',
+        'actorType',
+        'resourceType',
+        'country',
+    ];
+
+    /**
      * Filter methods that must be supplied at least one value. Empty `values`
      * arrays for these methods are rejected up front so they can't silently
      * compile into a "no filter applied" WHERE clause.
@@ -766,6 +776,8 @@ class ClickHouse extends SQL
         $tableName = $this->getTableName();
         $escapedDatabaseAndTable = $this->escapeIdentifier($this->database) . '.' . $this->escapeIdentifier($tableName);
 
+        $orderByExpr = $this->sharedTables ? '(tenant, time, id)' : '(time, id)';
+
         // Create table with MergeTree engine for optimal performance
         $createTableSql = "
             CREATE TABLE IF NOT EXISTS {$escapedDatabaseAndTable} (
@@ -773,9 +785,9 @@ class ClickHouse extends SQL
                 " . implode(",\n                ", $indexes) . "
             )
             ENGINE = MergeTree()
-            ORDER BY (time, id)
+            ORDER BY {$orderByExpr}
             PARTITION BY toYYYYMM(time)
-            SETTINGS index_granularity = 8192
+            SETTINGS index_granularity = 8192" . ($this->sharedTables ? ', allow_nullable_key = 1' : '') . "
         ";
 
         $this->query($createTableSql);
@@ -1962,9 +1974,19 @@ class ClickHouse extends SQL
             ? 'DateTime64(3)'
             : 'String';
 
-        $nullable = !$attribute['required'] ? 'Nullable(' . $type . ')' : $type;
+        $required = (bool) $attribute['required'];
 
-        return "{$id} {$nullable}";
+        if ($type === 'String' && \in_array($id, self::LOW_CARDINALITY_COLUMNS, true)) {
+            $columnType = $required
+                ? 'LowCardinality(String)'
+                : 'LowCardinality(Nullable(String))';
+
+            return "{$id} {$columnType}";
+        }
+
+        $columnType = !$required ? 'Nullable(' . $type . ')' : $type;
+
+        return "{$id} {$columnType}";
     }
 
     /**

--- a/tests/Audit/Adapter/ClickHouseTest.php
+++ b/tests/Audit/Adapter/ClickHouseTest.php
@@ -934,4 +934,68 @@ class ClickHouseTest extends TestCase
             Query::orderDesc('time'),
         ]);
     }
+
+    public function testSharedTableSortKeyLeadsWithTenant(): void
+    {
+        $host = getenv('CLICKHOUSE_HOST') ?: 'clickhouse';
+        $username = getenv('CLICKHOUSE_USER') ?: 'default';
+        $password = getenv('CLICKHOUSE_PASSWORD') ?: 'clickhouse';
+        $port = (int) (getenv('CLICKHOUSE_PORT') ?: 8123);
+        $secure = filter_var(getenv('CLICKHOUSE_SECURE') ?: false, FILTER_VALIDATE_BOOLEAN);
+        $database = getenv('CLICKHOUSE_DATABASE') ?: 'default';
+
+        $namespace = 'projtest_' . uniqid();
+
+        $adapter = new ClickHouse(
+            host: $host,
+            username: $username,
+            password: $password,
+            port: $port,
+            secure: $secure
+        );
+        $adapter->setDatabase($database);
+        $adapter->setNamespace($namespace);
+        $adapter->setSharedTables(true);
+        $adapter->setTenant(1);
+
+        $table = $namespace . '_audits';
+
+        $http = function (string $sql, array $params = []) use ($host, $port, $username, $password, $secure, $database): string {
+            $scheme = $secure ? 'https' : 'http';
+            $url = "{$scheme}://{$host}:{$port}/?database=" . rawurlencode($database)
+                . '&user=' . rawurlencode($username)
+                . '&password=' . rawurlencode($password);
+            foreach ($params as $key => $value) {
+                $url .= '&param_' . rawurlencode((string) $key) . '=' . rawurlencode((string) $value);
+            }
+            $ctx = stream_context_create(['http' => [
+                'method' => 'POST',
+                'header' => "Content-Type: text/plain\r\n",
+                'content' => $sql,
+                'timeout' => 15,
+                'ignore_errors' => true,
+            ]]);
+            $out = @file_get_contents($url, false, $ctx);
+
+            return $out === false ? '' : trim((string) $out);
+        };
+
+        try {
+            (new Audit($adapter))->setup();
+
+            $sortingKey = $http(
+                'SELECT sorting_key FROM system.tables WHERE database = {db:String} AND name = {tbl:String}',
+                ['db' => $database, 'tbl' => $table]
+            );
+
+            $this->assertTrue(
+                str_starts_with(trim($sortingKey), 'tenant'),
+                "Expected sorting key to lead with 'tenant', got: {$sortingKey}"
+            );
+        } finally {
+            $escDb = '`' . str_replace('`', '``', $database) . '`';
+            $escTbl = '`' . str_replace('`', '``', $table) . '`';
+            $http("DROP TABLE IF EXISTS {$escDb}.{$escTbl}");
+        }
+    }
 }


### PR DESCRIPTION
## Why

Appwrite Cloud is locked to `utopia-php/database 5.*` (via server-ce), so it cannot consume audit `2.5.0`/`2.6.0`, both of which require `database ^6.0.0`. This backports the tenant-leading ClickHouse sort-key work from #126 (released in 2.6.0) onto the `2.4.x` maintenance line, which stays on `database 5.*`.

## What

Same logical change as #126, adapted to the 2.4.2 adapter structure:

- **Tenant-leading sort key** in `setup()`'s `CREATE TABLE`: `ORDER BY (tenant, time, id)` when `sharedTables` is enabled, otherwise `ORDER BY (time, id)`.
- **`allow_nullable_key = 1`** appended to `SETTINGS` only for shared tables (tenant is `Nullable(UInt64)`).
- **LowCardinality columns** in the `CREATE TABLE` column definitions only: `event`, `actorType`, `resourceType` → `LowCardinality(String)`; `country` → `LowCardinality(Nullable(String))` (nullable wrapped inside).
- **Live test** `ClickHouseTest::testSharedTableSortKeyLeadsWithTenant()` asserts `system.tables.sorting_key` leads with `tenant` (runs against the docker-compose ClickHouse in CI).

No projection / `getSortingKey` / migration logic is introduced — the library stays fresh-schema-only. Index set and `query()` visibility are unchanged.

## Verification

- `composer install` resolves `utopia-php/database 5.0.0` (database stays on 5.*).
- `phpunit tests/Audit/QueryTest.php` → 11 passed.
- `pint --test` → pass; `phpstan analyse --level max src tests` → no errors.
- `php -l` clean on changed files. The live ClickHouse test passes in CI; locally it errors only on connection.

## Release

Should be released as **2.4.3**.
