### PR TITLE
feat(clickhouse): add optional retention TTL

### DIFF
--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -837,11 +837,18 @@ class ClickHouse extends SQL
         } else {
             // Disabling retention must actively strip any TTL a previous run
             // applied; otherwise rows keep being purged despite retention being
-            // null. REMOVE TTL is a no-op on a table without a TTL, so this is
-            // safe to run unconditionally and keeps setup() idempotent.
-            $this->query(
-                "ALTER TABLE {$escapedDatabaseAndTable} REMOVE TTL"
-            );
+            // null. ClickHouse errors (code 36) when REMOVE TTL runs on a table
+            // that has no TTL, so swallow that specific case to keep setup()
+            // idempotent.
+            try {
+                $this->query(
+                    "ALTER TABLE {$escapedDatabaseAndTable} REMOVE TTL"
+                );
+            } catch (Exception $e) {
+                if (!str_contains($e->getMessage(), "doesn't have any table TTL expression")) {
+                    throw $e;
+                }
+            }
         }
     }
 

--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -84,6 +84,9 @@ class ClickHouse extends SQL
 
     protected bool $asyncCleanup = false;
 
+    /** @var int|null Retention in days; when set, setup() applies a TTL on the table. Null disables TTL. */
+    protected ?int $retention = null;
+
     /**
      * @param string $host ClickHouse host
      * @param string $username ClickHouse username (default: 'default')
@@ -358,6 +361,34 @@ class ClickHouse extends SQL
     public function isAsyncCleanup(): bool
     {
         return $this->asyncCleanup;
+    }
+
+    /**
+     * Set the retention window in days. When set, setup() applies a TTL so
+     * rows older than the window are dropped by background merges. Pass null
+     * to disable (the default).
+     *
+     * @param int|null $days
+     * @return self
+     * @throws Exception If $days is not positive
+     */
+    public function setRetention(?int $days): self
+    {
+        if ($days !== null && $days < 1) {
+            throw new Exception('Retention must be a positive number of days');
+        }
+        $this->retention = $days;
+        return $this;
+    }
+
+    /**
+     * Get the retention window in days, or null when TTL is disabled.
+     *
+     * @return int|null
+     */
+    public function getRetention(): ?int
+    {
+        return $this->retention;
     }
 
     /**
@@ -791,6 +822,19 @@ class ClickHouse extends SQL
         ";
 
         $this->query($createTableSql);
+
+        // Apply retention as a separate, idempotent ALTER. CREATE TABLE IF NOT
+        // EXISTS won't add a TTL to a table that already exists, and MODIFY TTL
+        // is a no-op when the TTL already matches, so setup() stays re-runnable.
+        // materialize_ttl_after_modify = 0 defers the purge to background merges
+        // rather than an immediate, I/O-heavy mutation.
+        if ($this->retention !== null) {
+            $this->query(
+                "ALTER TABLE {$escapedDatabaseAndTable} "
+                . "MODIFY TTL toDateTime(time) + INTERVAL {$this->retention} DAY "
+                . 'SETTINGS materialize_ttl_after_modify = 0'
+            );
+        }
     }
 
     /**

--- a/src/Audit/Adapter/ClickHouse.php
+++ b/src/Audit/Adapter/ClickHouse.php
@@ -85,7 +85,7 @@ class ClickHouse extends SQL
     protected bool $asyncCleanup = false;
 
     /** @var int|null Retention in days; when set, setup() applies a TTL on the table. Null disables TTL. */
-    protected ?int $retention = null;
+    private ?int $retention = null;
 
     /**
      * @param string $host ClickHouse host
@@ -833,6 +833,14 @@ class ClickHouse extends SQL
                 "ALTER TABLE {$escapedDatabaseAndTable} "
                 . "MODIFY TTL toDateTime(time) + INTERVAL {$this->retention} DAY "
                 . 'SETTINGS materialize_ttl_after_modify = 0'
+            );
+        } else {
+            // Disabling retention must actively strip any TTL a previous run
+            // applied; otherwise rows keep being purged despite retention being
+            // null. REMOVE TTL is a no-op on a table without a TTL, so this is
+            // safe to run unconditionally and keeps setup() idempotent.
+            $this->query(
+                "ALTER TABLE {$escapedDatabaseAndTable} REMOVE TTL"
             );
         }
     }

--- a/tests/Audit/Adapter/ClickHouseTest.php
+++ b/tests/Audit/Adapter/ClickHouseTest.php
@@ -377,6 +377,74 @@ class ClickHouseTest extends TestCase
     }
 
     /**
+     * Test setRetention stores the value and getRetention returns it
+     */
+    public function testSetRetention(): void
+    {
+        $adapter = new ClickHouse(
+            host: 'clickhouse',
+            username: 'default',
+            password: 'clickhouse'
+        );
+
+        $this->assertNull($adapter->getRetention());
+
+        $result = $adapter->setRetention(30);
+        $this->assertInstanceOf(ClickHouse::class, $result);
+        $this->assertEquals(30, $adapter->getRetention());
+    }
+
+    /**
+     * Test setRetention accepts null to disable retention
+     */
+    public function testSetRetentionAcceptsNull(): void
+    {
+        $adapter = new ClickHouse(
+            host: 'clickhouse',
+            username: 'default',
+            password: 'clickhouse'
+        );
+
+        $adapter->setRetention(30);
+        $adapter->setRetention(null);
+        $this->assertNull($adapter->getRetention());
+    }
+
+    /**
+     * Test setRetention rejects zero days
+     */
+    public function testSetRetentionRejectsZero(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Retention must be a positive number of days');
+
+        $adapter = new ClickHouse(
+            host: 'clickhouse',
+            username: 'default',
+            password: 'clickhouse'
+        );
+
+        $adapter->setRetention(0);
+    }
+
+    /**
+     * Test setRetention rejects negative days
+     */
+    public function testSetRetentionRejectsNegative(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Retention must be a positive number of days');
+
+        $adapter = new ClickHouse(
+            host: 'clickhouse',
+            username: 'default',
+            password: 'clickhouse'
+        );
+
+        $adapter->setRetention(-1);
+    }
+
+    /**
      * Test shared tables configuration
      */
     public function testSharedTablesConfiguration(): void


### PR DESCRIPTION
## What

Adds `setRetention(?int $days)` to the ClickHouse audit adapter. When set, `setup()` applies an idempotent TTL to the audit table so rows past the retention window are dropped by background merges:

```php
$adapter->setRetention(30);
$audit->setup(); // ALTER TABLE ... MODIFY TTL toDateTime(time) + INTERVAL 30 DAY
```

Default `null` preserves current behaviour (no TTL).

## Why in setup()

Retention is part of the table's schema, and `setup()` already owns everything else about it (columns, indexes, engine, partition key). Keeping TTL here means every caller that already runs `setup()` gets retention with no extra plumbing, and the table-naming logic isn't duplicated downstream.

## How

- Applied as a **separate** `ALTER … MODIFY TTL`, not baked into `CREATE TABLE`, because `CREATE TABLE IF NOT EXISTS` won't touch an already-existing table. `MODIFY TTL` is a no-op when the expression is unchanged, so `setup()` stays re-runnable/idempotent.
- `SETTINGS materialize_ttl_after_modify = 0` defers the purge to normal background merges instead of an immediate, I/O-heavy mutation.
- `time` is `DateTime64(3)`; `toDateTime(time)` narrows it for the TTL expression.
- `setRetention()` rejects non-positive day counts.

Pint (`composer lint`) and PHPStan level max (`composer check`) pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)